### PR TITLE
fix: update bobravoz transport config and realtime routing

### DIFF
--- a/internal/hub/buffer_test.go
+++ b/internal/hub/buffer_test.go
@@ -260,6 +260,7 @@ func TestBufferConcurrentEnqueueAndFlush(t *testing.T) {
 	const messagesPerEnqueuer = 100
 
 	var wg sync.WaitGroup
+	enqueuersDone := make(chan struct{})
 
 	// Start 10 goroutines each enqueuing messages
 	for i := range numEnqueuers {
@@ -278,6 +279,10 @@ func TestBufferConcurrentEnqueueAndFlush(t *testing.T) {
 			}
 		}(i)
 	}
+	go func() {
+		wg.Wait()
+		close(enqueuersDone)
+	}()
 
 	// Start 1 goroutine flushing periodically
 	flushDone := make(chan struct{})
@@ -285,31 +290,29 @@ func TestBufferConcurrentEnqueueAndFlush(t *testing.T) {
 	go func() {
 		defer close(flushDone)
 		ctx := context.Background()
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
 		for {
 			select {
-			case <-time.After(time.Millisecond):
+			case <-ticker.C:
 				flushed, _ := buf.FlushWithSender(ctx, func(pkt *transportpb.DataPacket) error {
 					return nil
 				})
 				totalFlushed += int64(flushed)
-			default:
+			case <-enqueuersDone:
 				if buf.Size() == 0 {
-					// Check if all enqueuers are done
-					time.Sleep(10 * time.Millisecond)
-					// Final flush
-					flushed, _ := buf.FlushWithSender(ctx, func(pkt *transportpb.DataPacket) error {
-						return nil
-					})
-					totalFlushed += int64(flushed)
-					if buf.Size() == 0 {
-						return
-					}
+					return
+				}
+				flushed, _ := buf.FlushWithSender(ctx, func(pkt *transportpb.DataPacket) error {
+					return nil
+				})
+				totalFlushed += int64(flushed)
+				if buf.Size() == 0 {
+					return
 				}
 			}
 		}
 	}()
-
-	wg.Wait()
 
 	// Wait for flush goroutine to finish
 	select {

--- a/internal/hub/server.go
+++ b/internal/hub/server.go
@@ -556,7 +556,6 @@ func (s *Server) Process(stream transportpb.HubService_ProcessServer) error {
 	meta.Info(s.log, "Hub stream registered successfully")
 	defer func() {
 		s.streamManager.RemoveStream(storyRunName, storyRunNS, currentStepID, streamEntry)
-		s.releaseLifecycleHooksForStoryRun(storyRunName, storyRunNS)
 		s.maybeSignalTopologyTerminated(storyRunName, storyRunNS)
 	}()
 	streamContract = streamContract.WithStage(meta)
@@ -898,20 +897,6 @@ func (s *Server) releaseLifecycleHook(key string) {
 	delete(s.emittedHooks, key)
 }
 
-// releaseLifecycleHooksForStoryRun removes all emitted-hook entries whose key
-// contains the given storyrun identifier. Call this when a storyrun's streaming
-// topology is torn down to prevent unbounded map growth.
-func (s *Server) releaseLifecycleHooksForStoryRun(storyRunName, storyRunNamespace string) {
-	prefix := storyRunNamespace + "/" + storyRunName + ":"
-	s.hookMu.Lock()
-	defer s.hookMu.Unlock()
-	for key := range s.emittedHooks {
-		if strings.HasPrefix(key, prefix) {
-			delete(s.emittedHooks, key)
-		}
-	}
-}
-
 // recvResult represents the result of a stream.Recv() operation
 type recvResult struct {
 	req *transportpb.ProcessRequest
@@ -1136,7 +1121,12 @@ func (s *Server) processPacket(ctx context.Context, storyRunName, storyRunNS, cu
 		if sourceEngram, resolveErr := s.resolveEngramForStep(ctx, storyRun.Namespace, currentStep); resolveErr == nil {
 			outputMap := mergeMaps(payloadAsMap(in.Payload), payloadAsMap(in.Inputs))
 			if valErr := s.validateEngramOutputs(ctx, currentStepID, sourceEngram, outputMap); valErr != nil {
-				return finalize(valErr)
+				s.log.Error(valErr, "Dropping packet with invalid current step outputs",
+					"storyRun", storyRunName,
+					"namespace", storyRunNS,
+					"step", currentStepID,
+				)
+				return finalize(nil)
 			}
 		}
 	}

--- a/internal/hub/server.go
+++ b/internal/hub/server.go
@@ -2074,6 +2074,9 @@ func (s *Server) forwardToRealtimeStep(
 		Envelope:   cloneDownstreamEnvelope(originalPacket.GetEnvelope()),
 	}
 	cloneDataPacketFrame(out, originalPacket)
+	if err := applyRuntimePayloadIsolation(out, nextEngramStep, evaluatedInputs, originalPacket); err != nil {
+		return err
+	}
 
 	retryPolicy := resolveStreamingRetryPolicy(nextEngramStep, story)
 	sendCtx, cancel := s.contextWithStepTimeout(ctx, nextEngramStep, story)
@@ -2097,6 +2100,33 @@ func (s *Server) forwardToRealtimeStep(
 	}); !ok {
 		s.log.Info("Failed to deliver or buffer packet; dropping and closing stream", "storyRun", storyRun.Name, "downstreamStep", nextEngramStepID, "reason", "buffer_exhausted")
 		return status.Errorf(codes.ResourceExhausted, "downstream buffer full for step %q", nextEngramStepID)
+	}
+	return nil
+}
+
+func applyRuntimePayloadIsolation(out *transportpb.DataPacket, step *bubuv1alpha1.Step, evaluatedInputs *structpb.Struct, originalPacket *transportpb.DataPacket) error {
+	if out == nil || step == nil || step.Runtime == nil || len(step.Runtime.Raw) == 0 || evaluatedInputs == nil {
+		return nil
+	}
+
+	out.Payload = cloneStruct(evaluatedInputs)
+
+	// Runtime inputs are the downstream component contract for structured
+	// packets. Preserve audio/video media frames, but replace structured binary
+	// payloads so upstream config fields cannot leak into the next component.
+	if originalPacket.GetAudio() != nil || originalPacket.GetVideo() != nil {
+		return nil
+	}
+
+	body, err := json.Marshal(evaluatedInputs.AsMap())
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to encode runtime payload for step %q: %v", getStepID(step), err)
+	}
+	out.Frame = &transportpb.DataPacket_Binary{
+		Binary: &transportpb.BinaryFrame{
+			Payload:  body,
+			MimeType: "application/json",
+		},
 	}
 	return nil
 }

--- a/internal/hub/server_test.go
+++ b/internal/hub/server_test.go
@@ -1131,6 +1131,69 @@ func TestProcessPacket_StreamingWithValidationBlocksStepsContext(t *testing.T) {
 	assert.Contains(t, err.Error(), "with block not valid for streaming")
 }
 
+func TestProcessPacket_DropsInvalidCurrentStepOutputWithoutDisconnect(t *testing.T) {
+	ns := "ns"
+	story := &bubuv1alpha1.Story{
+		ObjectMeta: metav1.ObjectMeta{Name: "story", Namespace: ns},
+		Spec: bubuv1alpha1.StorySpec{
+			Pattern: enums.RealtimePattern,
+			Steps: []bubuv1alpha1.Step{
+				{
+					Name: "step-a",
+					Ref:  &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "engram-a"}},
+				},
+				{
+					Name:  "step-b",
+					Needs: []string{"step-a"},
+					Ref:   &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "engram-b"}},
+				},
+			},
+		},
+	}
+	storyRun := &runsv1alpha1.StoryRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "storyrun", Namespace: ns},
+		Spec: runsv1alpha1.StoryRunSpec{
+			StoryRef: refs.StoryReference{ObjectReference: refs.ObjectReference{Name: "story"}},
+		},
+	}
+	engramA := &bubuv1alpha1.Engram{
+		ObjectMeta: metav1.ObjectMeta{Name: "engram-a", Namespace: ns},
+		Spec: bubuv1alpha1.EngramSpec{
+			Mode:        enums.WorkloadModeDeployment,
+			TemplateRef: refs.EngramTemplateReference{Name: "strict-template"},
+		},
+	}
+	engramB := &bubuv1alpha1.Engram{
+		ObjectMeta: metav1.ObjectMeta{Name: "engram-b", Namespace: ns},
+		Spec: bubuv1alpha1.EngramSpec{
+			Mode:        enums.WorkloadModeDeployment,
+			TemplateRef: refs.EngramTemplateReference{Name: "tmpl"},
+		},
+	}
+	strictTemplate := &catalogv1alpha1.EngramTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "strict-template"},
+		Spec: catalogv1alpha1.EngramTemplateSpec{
+			OutputSchema: rawExtensionFromMap(t, map[string]any{
+				"type":     "object",
+				"required": []any{"ok"},
+				"properties": map[string]any{
+					"ok": map[string]any{"type": "string"},
+				},
+			}),
+		},
+	}
+	s := newTestServer(t, story, storyRun, engramA, engramB, strictTemplate)
+	payload, err := structpb.NewStruct(map[string]any{"text": "invalid for strict-template"})
+	require.NoError(t, err)
+	packet := &transportpb.DataPacket{Payload: payload}
+
+	require.NoError(t, s.processPacket(context.Background(), storyRun.Name, ns, "step-a", packet))
+
+	keyB := s.streamManager.streamKey(storyRun.Name, ns, "step-b")
+	_, routed := s.streamManager.buffers.Load(keyB)
+	require.False(t, routed, "invalid source output should be dropped before downstream routing")
+}
+
 func TestStreamingTemplateScopes(t *testing.T) {
 	staticScope := streamingStaticScope()
 	runtimeScope := streamingRuntimeScope()
@@ -1312,6 +1375,59 @@ func TestServer_Process_RejectsMissingConnectorGeneration(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 	assert.Contains(t, err.Error(), "missing connector-generation metadata")
+}
+
+func TestServer_ProcessKeepsLifecycleDedupOnStreamClose(t *testing.T) {
+	ns := "test-ns"
+	storyRunName := "test-storyrun"
+	story := &bubuv1alpha1.Story{
+		ObjectMeta: metav1.ObjectMeta{Name: "story", Namespace: ns},
+		Spec: bubuv1alpha1.StorySpec{
+			Pattern: enums.RealtimePattern,
+			Steps: []bubuv1alpha1.Step{
+				{
+					Name:      "ingress",
+					Transport: "chat",
+					Ref:       &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "livekit-bridge"}},
+				},
+			},
+		},
+	}
+	storyRun := &runsv1alpha1.StoryRun{
+		ObjectMeta: metav1.ObjectMeta{Name: storyRunName, Namespace: ns},
+		Spec: runsv1alpha1.StoryRunSpec{
+			StoryRef: refs.StoryReference{ObjectReference: refs.ObjectReference{Name: story.Name}},
+		},
+	}
+	engram := &bubuv1alpha1.Engram{
+		ObjectMeta: metav1.ObjectMeta{Name: "livekit-bridge", Namespace: ns},
+		Spec: bubuv1alpha1.EngramSpec{
+			Mode:        enums.WorkloadModeDeployment,
+			TemplateRef: refs.EngramTemplateReference{Name: "livekit-bridge"},
+		},
+	}
+	s := newTestServer(t, story, storyRun, engram)
+	key := lifecycleHookDedupKey(ns, storyRunName, lifecycleHookStoryReadyEvent, "")
+	require.True(t, s.claimLifecycleHook(key))
+
+	md := metadata.New(map[string]string{
+		metaStoryRunName:                  storyRunName,
+		metaStoryRunNS:                    ns,
+		metaCurrentStepID:                 "ingress",
+		metaConnectorGeneration:           "1",
+		coretransport.ProtocolMetadataKey: coretransport.ProtocolVersion,
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	stream := newMockStream(ctx)
+	close(stream.RecvChan)
+	stream.On("Context").Return(ctx)
+
+	require.NoError(t, s.Process(stream))
+
+	s.hookMu.Lock()
+	_, exists := s.emittedHooks[key]
+	s.hookMu.Unlock()
+	require.True(t, exists, "ordinary stream close must not clear StoryRun lifecycle dedupe")
 }
 
 func TestServer_Process_RejectsInvalidConnectorGeneration(t *testing.T) {

--- a/internal/hub/server_test.go
+++ b/internal/hub/server_test.go
@@ -55,6 +55,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const chatMessageTypeCondition = "{{ eq (default \"\" packet.metadata.type) \"chat.message.v1\" }}"
+
 // mockStream is a mock of the HubService_ProcessServer interface
 type mockStream struct {
 	mock.Mock
@@ -229,6 +231,18 @@ func rawExtensionFromMap(t *testing.T, data map[string]any) *runtime.RawExtensio
 	return &runtime.RawExtension{Raw: b}
 }
 
+func bufferedPacketForStep(t *testing.T, s *Server, storyRunName, ns, stepID string) *transportpb.DataPacket {
+	t.Helper()
+	key := s.streamManager.streamKey(storyRunName, ns, stepID)
+	val, ok := s.streamManager.buffers.Load(key)
+	require.True(t, ok, "expected buffered packet for step %q", stepID)
+	buf := val.(*MessageBuffer)
+	buf.mu.Lock()
+	defer buf.mu.Unlock()
+	require.NotEmpty(t, buf.messages, "expected buffered messages for step %q", stepID)
+	return buf.messages[0]
+}
+
 func TestEvaluateStepCondition_StaticFalse(t *testing.T) {
 	s := newTestServer(t)
 	expr := "{{ eq inputs.flag true }}"
@@ -255,7 +269,7 @@ func TestEvaluateStepCondition_RuntimePacket(t *testing.T) {
 
 func TestEvaluateStepCondition_RuntimePacketMetadataMissingDoesNotFail(t *testing.T) {
 	s := newTestServer(t)
-	expr := "{{ eq (default \"\" packet.metadata.type) \"chat.message.v1\" }}"
+	expr := chatMessageTypeCondition
 	payload, err := structpb.NewStruct(map[string]any{"text": "hello"})
 	require.NoError(t, err)
 
@@ -835,7 +849,7 @@ func TestProcessPacket_RuntimeIfSkipsBranch(t *testing.T) {
 
 func TestProcessPacket_RuntimeMetadataIfSkipsBranchWithoutCrashing(t *testing.T) {
 	ns := "ns"
-	ifExpr := "{{ eq (default \"\" packet.metadata.type) \"chat.message.v1\" }}"
+	ifExpr := chatMessageTypeCondition
 	story := &bubuv1alpha1.Story{
 		ObjectMeta: metav1.ObjectMeta{Name: "story", Namespace: ns},
 		Spec: bubuv1alpha1.StorySpec{
@@ -1192,6 +1206,133 @@ func TestProcessPacket_DropsInvalidCurrentStepOutputWithoutDisconnect(t *testing
 	keyB := s.streamManager.streamKey(storyRun.Name, ns, "step-b")
 	_, routed := s.streamManager.buffers.Load(keyB)
 	require.False(t, routed, "invalid source output should be dropped before downstream routing")
+}
+
+func TestProcessPacket_LiveKitChatRuntimeRoutesPacketTextWithoutMemory(t *testing.T) {
+	ns := "ns"
+	chatType := "chat.message.v1"
+	chatCondition := chatMessageTypeCondition
+	story := &bubuv1alpha1.Story{
+		ObjectMeta: metav1.ObjectMeta{Name: "story", Namespace: ns},
+		Spec: bubuv1alpha1.StorySpec{
+			Pattern: enums.RealtimePattern,
+			Steps: []bubuv1alpha1.Step{
+				{
+					Name: "ingress",
+					Ref:  &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "livekit-bridge"}},
+				},
+				{
+					Name:  "respond",
+					Needs: []string{"ingress"},
+					If:    &chatCondition,
+					Ref:   &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "assistant"}},
+					Runtime: rawExtensionFromMap(t, map[string]any{
+						"userPrompt": "{{ default \"\" packet.text }}",
+						"speakerId":  "{{ inputs.participant.identity }}",
+					}),
+				},
+			},
+		},
+	}
+	storyRun := &runsv1alpha1.StoryRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "storyrun", Namespace: ns},
+		Spec: runsv1alpha1.StoryRunSpec{
+			StoryRef: refs.StoryReference{ObjectReference: refs.ObjectReference{Name: "story"}},
+			Inputs: rawExtensionFromMap(t, map[string]any{
+				"participant": map[string]any{"identity": "alice"},
+			}),
+		},
+	}
+	assistant := &bubuv1alpha1.Engram{
+		ObjectMeta: metav1.ObjectMeta{Name: "assistant", Namespace: ns},
+		Spec:       bubuv1alpha1.EngramSpec{Mode: enums.WorkloadModeDeployment},
+	}
+	s := newTestServer(t, story, storyRun, assistant)
+	payload, err := structpb.NewStruct(map[string]any{
+		"text":   "hello from chat",
+		"sender": "alice",
+		"topic":  "lk.chat",
+	})
+	require.NoError(t, err)
+	packet := &transportpb.DataPacket{
+		Payload:  payload,
+		Metadata: map[string]string{"type": chatType},
+	}
+
+	require.NoError(t, s.processPacket(context.Background(), storyRun.Name, ns, "ingress", packet))
+
+	routed := bufferedPacketForStep(t, s, storyRun.Name, ns, "respond")
+	require.NotNil(t, routed.GetInputs())
+	assert.Equal(t, "hello from chat", routed.GetInputs().AsMap()["userPrompt"])
+	assert.Equal(t, "alice", routed.GetInputs().AsMap()["speakerId"])
+}
+
+func TestProcessPacket_RuntimeInputsReplaceStructuredPayloadAndBinary(t *testing.T) {
+	ns := "ns"
+	story := &bubuv1alpha1.Story{
+		ObjectMeta: metav1.ObjectMeta{Name: "story", Namespace: ns},
+		Spec: bubuv1alpha1.StorySpec{
+			Pattern: enums.RealtimePattern,
+			Steps: []bubuv1alpha1.Step{
+				{
+					Name: "transcribe",
+					Ref:  &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "stt"}},
+				},
+				{
+					Name:  "translate",
+					Needs: []string{"transcribe"},
+					Ref:   &refs.EngramReference{ObjectReference: refs.ObjectReference{Name: "translator"}},
+					Runtime: rawExtensionFromMap(t, map[string]any{
+						"userPrompt": "{{ default \"\" packet.text }}",
+						"speakerId":  "{{ inputs.participant.identity }}",
+					}),
+				},
+			},
+		},
+	}
+	storyRun := &runsv1alpha1.StoryRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "storyrun", Namespace: ns},
+		Spec: runsv1alpha1.StoryRunSpec{
+			StoryRef: refs.StoryReference{ObjectReference: refs.ObjectReference{Name: "story"}},
+			Inputs: rawExtensionFromMap(t, map[string]any{
+				"participant": map[string]any{"identity": "alice"},
+			}),
+		},
+	}
+	translator := &bubuv1alpha1.Engram{
+		ObjectMeta: metav1.ObjectMeta{Name: "translator", Namespace: ns},
+		Spec:       bubuv1alpha1.EngramSpec{Mode: enums.WorkloadModeDeployment},
+	}
+	s := newTestServer(t, story, storyRun, translator)
+	upstreamPayload := []byte(`{"text":"hello","responseFormat":"json","stream":false,"model":"gpt-4o-mini-transcribe","task":"transcribe"}`)
+	payload, err := structpb.NewStruct(map[string]any{
+		"text":           "hello",
+		"responseFormat": "json",
+		"stream":         false,
+		"model":          "gpt-4o-mini-transcribe",
+		"task":           "transcribe",
+	})
+	require.NoError(t, err)
+	packet := &transportpb.DataPacket{
+		Payload: payload,
+		Frame: &transportpb.DataPacket_Binary{
+			Binary: &transportpb.BinaryFrame{
+				Payload:  upstreamPayload,
+				MimeType: "application/json",
+			},
+		},
+	}
+
+	require.NoError(t, s.processPacket(context.Background(), storyRun.Name, ns, "transcribe", packet))
+
+	routed := bufferedPacketForStep(t, s, storyRun.Name, ns, "translate")
+	require.NotNil(t, routed.GetPayload())
+	assert.Equal(t, "hello", routed.GetPayload().AsMap()["userPrompt"])
+	assert.NotContains(t, routed.GetPayload().AsMap(), "responseFormat")
+	require.NotNil(t, routed.GetBinary())
+	assert.JSONEq(t, `{"speakerId":"alice","userPrompt":"hello"}`, string(routed.GetBinary().GetPayload()))
+	assert.Equal(t, "application/json", routed.GetBinary().GetMimeType())
+	assert.NotContains(t, string(routed.GetBinary().GetPayload()), "responseFormat")
 }
 
 func TestStreamingTemplateScopes(t *testing.T) {


### PR DESCRIPTION
## Summary
- update bobravoz dependencies and typed transport config handling
- keep hub streams stable when output schema validation rejects a packet
- isolate runtime-mapped realtime payloads so downstream components receive evaluated runtime inputs

## Verification
- GOCACHE=/tmp/bubustack-go-cache make test
- GOCACHE=/tmp/bubustack-go-cache make lint

## Notes
- No GitHub trackers were closed. Existing realtime follow-ups should be updated after release/live validation.